### PR TITLE
fix: planted saplings will actually grow

### DIFF
--- a/src/main/java/org/terasology/gf/SaplingInitializeSystem.java
+++ b/src/main/java/org/terasology/gf/SaplingInitializeSystem.java
@@ -19,7 +19,8 @@ import org.joml.Vector3ic;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.engine.entitySystem.entity.EntityRef;
-import org.terasology.engine.entitySystem.entity.lifecycleEvents.OnAddedComponent;
+import org.terasology.engine.entitySystem.entity.lifecycleEvents.OnActivatedComponent;
+import org.terasology.engine.entitySystem.event.EventPriority;
 import org.terasology.engine.entitySystem.event.ReceiveEvent;
 import org.terasology.engine.entitySystem.systems.BaseComponentSystem;
 import org.terasology.engine.entitySystem.systems.RegisterMode;
@@ -66,14 +67,14 @@ public class SaplingInitializeSystem extends BaseComponentSystem {
     private boolean processingEvent;
 
     @ReceiveEvent
-    public void generatedSaplingLoaded(OnAddedComponent event, EntityRef sapling,
+    public void generatedSaplingLoaded(OnActivatedComponent event, EntityRef sapling,
                                        GeneratedSaplingComponent generatedSaplingComponent, BlockComponent blockComponent) {
         delayManager.addDelayedAction(sapling, INITIALIZE_PLANT_ACTION, 0);
     }
 
-    @ReceiveEvent
-    public void plantedSapling(OnAddedComponent event, EntityRef sapling, LivingPlantComponent livingPlant,
-                               PlantedSaplingComponent plantedSaplingComponent, LivingPlantComponent livingPlantComponent,
+    @ReceiveEvent(priority = EventPriority.PRIORITY_LOW)
+    public void plantedSapling(OnActivatedComponent event, EntityRef sapling, LivingPlantComponent livingPlant,
+                               PlantedSaplingComponent plantedSaplingComponent,
                                BlockComponent blockComponent) {
         if (!processingEvent) {
             processingEvent = true;


### PR DESCRIPTION
Planted saplings may have grown in the past a small percentage of the time, but now they do it reliably. Try testing with https://github.com/Terasology/MetalRenegades/pull/161, `give BaobabSapling` or `give MetalRenegades:CypressSapling`, plant it, probably increase the time dilation, and wait a bit.

Trees that generate in the world almost always still don't grow, and that's partially because `OnActivatedComponent` events aren't sent until something interacts with a block with an attached entity (e.g. looking at it, this is what causes https://github.com/Terasology/GrowingFlora/issues/2) and partially because of other problems I haven't figured out yet.