### PR TITLE
fix: NullPointerException in Advanced Game Setup

### DIFF
--- a/src/main/java/org/terasology/gf/generator/FloraFeatureGenerator.java
+++ b/src/main/java/org/terasology/gf/generator/FloraFeatureGenerator.java
@@ -42,13 +42,12 @@ public class FloraFeatureGenerator implements WorldRasterizer {
     private Map<Name, DiscreteDistribution<PlantSpawnDefinition>> foliageDefinitionsCache = new HashMap<>();
 
     public FloraFeatureGenerator() {
-        loadPlantGrowthDefinitions();
-        loadPlantSpawnDefinition();
-
     }
 
     @Override
     public void initialize() {
+        loadPlantGrowthDefinitions();
+        loadPlantSpawnDefinition();
     }
 
     private void loadPlantGrowthDefinitions() {


### PR DESCRIPTION
This just moves loading of definitions to `initialize()`, which runs after the preview screens when the plugin library has actually been registered.